### PR TITLE
don't use deprecated util.pump

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -52,7 +52,11 @@ function copyFile(src, dst, cb) {
 
             var is = fs.createReadStream(src);
             var os = fs.createWriteStream(dst);
-            util.pump(is, os, cb);
+
+            is.on("error", cb);
+            os.on("error", cb);
+            os.on("close", cb);
+            is.pipe (os);            
       });
     });
 }

--- a/logger.js
+++ b/logger.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var datetime = require('datetime');
-var express = require('express');
+var morgan = require('morgan');
 var mkdirsSync = require('mkdir').mkdirsSync;
 
 // *************************************************************************************************
@@ -17,7 +17,7 @@ module.exports = function(options) {
     mkdirsSync(path.dirname(options.path));
 
     var logStream = fs.createWriteStream(options.path, {flags: 'a'});
-    var logger = express.logger({stream: logStream, format: options.format});
+    var logger = morgan({stream: logStream, format: options.format});
 
     // XXXjoe Need to expose a way to cancel this timer
     var archiveInterval = setInterval(function() {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "author": "Joe Hewitt <joe@joehewitt.com>",
   "dependencies": {
     "datetime": "",
-    "express": "2.5.9",
-    "mkdir": ""
+    "mkdir": "",
+    "morgan": "^1.8.2"
   },
   "engines": {
     "node": ">=0.4.0"


### PR DESCRIPTION
Newest versions of node util don't come with pump, messing up the log rotation. Move to using pipe.